### PR TITLE
Fix denominator check in specular_rt

### DIFF
--- a/iadpython/fresnel.py
+++ b/iadpython/fresnel.py
@@ -176,7 +176,7 @@ def fresnel_reflection(n_i, nu_i, n_t):
     dif2 = (n_i * nu_i - n_t * nu_t) ** 2
 
     if np.isscalar(sum1):
-        if nu_i == 0:       # angle is greater than critical angle
+        if nu_t == 0:       # angle is greater than critical angle
             return 1
         return (dif1 / sum1 + dif2 / sum2) / 2
 
@@ -373,7 +373,8 @@ def _specular_rt(n_top, n_slab, n_bot, b_slab, nu, b_top=0, b_bot=0):
     numer = r_bottom * t_top**2 * expo**2
 
     if np.isscalar(denom):
-        denom = 1
+        if denom == 0:
+            denom = 1
     else:
         np.place(denom, denom == 0, 1)
 

--- a/iadpython/start.py
+++ b/iadpython/start.py
@@ -321,7 +321,7 @@ def unscattered(s):
 
     for i in range(n):
         nu_outside = iad.cos_snell(s.n, s.nu[i], 1.0)
-        if nu_outside == 0:
+        if nu_outside > 0:
             r, t = iad.specular_rt(s.n_above, s.n, s.n_below,
                                    s.b_above, s.b, s.b_below, nu_outside)
             uru += s.twonuw[i] * r[i, i]


### PR DESCRIPTION
## Summary
- fix the logic for skipping angles when computing unscattered reflection
- correct scalar denominator handling in Fresnel specular RT
- detect total internal reflection using the transmitted cosine

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several modules)*

------
https://chatgpt.com/codex/tasks/task_e_68522c0265dc8331890ae702cf1e152a