### PR TITLE
Handle wavelength-dependent phase data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,10 @@ The following will do a forward calculation::
     print('  total reflection = %.5f' % uru)
     print('  total transmission = %.5f' % utu)
 
+`Sample` also accepts tabulated phase-function data via the ``pf_data``
+keyword. When ``pf_type`` is ``'TABULATED'``, ``pf_data`` may hold one column per
+wavelength and must have the same length as other wavelength-dependent inputs.
+
 
 Installation
 ------------


### PR DESCRIPTION
## Summary
- add `pf_data` property in `Sample`
- support phase data with multiple columns in `Sample.rt`
- document how `pf_data` can hold per-wavelength columns
- compute length of phase-function data using either `g` or `pf_data`

## Testing
- `ruff check -q` *(fails: trailing whitespace and other existing issues)*
- `pytest -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6852e959741483319465b0efa40c0181